### PR TITLE
Adds support for Python 3.7+ (async keyword)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: python
 
 python:
+  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 # Config file for automatic testing at travis-ci.org
 language: python
 
+dist: xenial
+sudo: required
+
 python:
+  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"
@@ -19,10 +23,6 @@ matrix:
   include:
     - env: TOXENV=docs
     - env: TOXENV=lint
-    - python: "3.7"
-      dist: xenial
-      sudo: required
-      language: python
 
 install:
   - sudo apt-get install libsnappy-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 
 python:
-  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"
@@ -20,6 +19,10 @@ matrix:
   include:
     - env: TOXENV=docs
     - env: TOXENV=lint
+    - python: "3.7"
+      dist: xenial
+      sudo: required
+      language: python
 
 install:
   - sudo apt-get install libsnappy-dev

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ History
 
 * Drop support for python 2.6 and python 3.3
 * Handle changing connections during redistribute ready
+* Add support for python 3.7+ (async keyword)
 
 
 0.4.0 (2017-06-13)

--- a/gnsq/contrib/batch.py
+++ b/gnsq/contrib/batch.py
@@ -18,7 +18,7 @@ class BatchHandler(object):
     larger then the batch size.
 
     Example usage:
-    >>> reader = Reader('topic', 'worker', async=True, max_in_flight=16)
+    >>> reader = Reader('topic', 'worker', async_mode=True, max_in_flight=16)
     >>> reader.on_message.connect(BatchHandler(8, my_handler), weak=False)
     """
     def __init__(self, batch_size, handle_batch=None, handle_message=None,

--- a/gnsq/nsqd.py
+++ b/gnsq/nsqd.py
@@ -234,9 +234,9 @@ class Nsqd(HTTPClient):
         self.state = DISCONNECTED
         self.on_close.send(self)
 
-    def send(self, data, async=False):
+    def send(self, data, async_mode=False):
         try:
-            return self.stream.send(data, async)
+            return self.stream.send(data, async_mode)
         except Exception:
             self.close_stream()
             raise

--- a/gnsq/reader.py
+++ b/gnsq/reader.py
@@ -37,7 +37,7 @@ class Reader(object):
     `message_handler`.
 
     Messages will automatically be finished when the message handle returns
-    unless the readers `async` flag is set to `True`. If an exception occurs or
+    unless the readers `async_mode` flag is set to `True`. If an exception occurs or
     :class:`gnsq.errors.NSQRequeueMessage` is raised, the message will be
     requeued.
 
@@ -61,7 +61,7 @@ class Reader(object):
     :param message_handler: the callable that will be executed for each message
         received
 
-    :param async: consider the message handling to be async. The message will
+    :param async_mode: consider the message handling to be async. The message will
         not automatically be finished after the handler returns and must
         manually be called
 
@@ -107,7 +107,7 @@ class Reader(object):
         lookupd_http_addresses=[],
         name=None,
         message_handler=None,
-        async=False,
+        async_mode=False,
         max_tries=5,
         max_in_flight=1,
         max_concurrency=0,
@@ -132,7 +132,7 @@ class Reader(object):
 
         self.topic = topic
         self.channel = channel
-        self.async = async
+        self.async_mode = async_mode
         self.max_tries = max_tries
         self.max_in_flight = max_in_flight
         self.requeue_delay = requeue_delay
@@ -689,7 +689,7 @@ class Reader(object):
         if not self.is_running:
             return
 
-        if self.async:
+        if self.async_mode:
             return
 
         if message.has_responded():

--- a/gnsq/stream/stream.py
+++ b/gnsq/stream/stream.py
@@ -86,13 +86,13 @@ class Stream(object):
 
         return data
 
-    def send(self, data, async=False):
+    def send(self, data, async_mode=False):
         self.ensure_connection()
 
         result = AsyncResult()
         self.queue.put((data, result))
 
-        if async:
+        if async_mode:
             return result
 
         result.get()

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, docs, py27, py34, py35, py36, pypy
+envlist = lint, docs, py27, py34, py35, py36, py37, pypy
 
 [testenv]
 deps = -r{toxinidir}/requirements.test.txt


### PR DESCRIPTION
According to Python 3.7 documentation:
> Backwards incompatible syntax changes:
> async and await are now reserved keywords.

So, `async` arguments and flags were replaced with `async_mode`