### PR TITLE
Fix HTTPClient request method for NSQ 0.x version

### DIFF
--- a/gnsq/httpclient.py
+++ b/gnsq/httpclient.py
@@ -91,7 +91,7 @@ class HTTPClient(object):
 
         # Handle 1.0.0-compat vs 0.x versions
         try:
-            data['data']
+            return data['data']
         except KeyError:
             return data
 


### PR DESCRIPTION
This bug has been introduced by commit 8d73ce8 ("Split nsqd http and tcp
clients").